### PR TITLE
Add loading screens for API actions

### DIFF
--- a/src/app/dashboard/account/page.tsx
+++ b/src/app/dashboard/account/page.tsx
@@ -2,16 +2,7 @@ import * as React from "react";
 import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-
-<<<<<<< HEAD
-import { config } from '@/config';
-import { AccountDetailsForm } from '@/features/dashboard/account/account-details-form';
-import { AccountInfo } from '@/features/dashboard/account/account-info';
-
-export const metadata = { title: `Account | Dashboard | ${config.site.name}` } satisfies Metadata;
-=======
-import BalanceSummary from "@/components/dashboard/account/balance-summary";
->>>>>>> main
+import BalanceSummary from "@/features/dashboard/account/balance-summary";
 
 export default function Page(): React.JSX.Element {
 	return (

--- a/src/app/dashboard/categories/page.tsx
+++ b/src/app/dashboard/categories/page.tsx
@@ -12,6 +12,7 @@ import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
 import { Category } from "@/types/nav";
 import { createCategory, getAllCategories } from "@/lib/api/category";
 import DataTable from "@/components/core/table";
+import LoadingScreen from "@/components/core/loading-screen";
 
 const categoriesColumns: GridColDef[] = [
 	{ field: "id", headerName: "ID", flex: 0.1, minWidth: 40 },
@@ -24,18 +25,25 @@ const categoriesColumns: GridColDef[] = [
 ];
 
 export default function Page(): React.JSX.Element {
-	const [categories, setCategories] = React.useState<Category[]>();
-	const [open, setOpen] = React.useState(false);
-	React.useEffect(() => {
-		getAllCategories().then(setCategories).catch(console.error);
-	}, []);
-        const handleSubmit = (input: unknown) => {
-                input.preventDefault();
-                const value = input.target[0].value;
+        const [categories, setCategories] = React.useState<Category[]>();
+        const [open, setOpen] = React.useState(false);
+        const [loading, setLoading] = React.useState(false);
+        React.useEffect(() => {
+                setLoading(true);
+                getAllCategories()
+                        .then(setCategories)
+                        .catch(console.error)
+                        .finally(() => setLoading(false));
+        }, []);
+        const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+                event.preventDefault();
+                const value = (event.currentTarget.elements[0] as HTMLInputElement).value;
+                setLoading(true);
                 createCategory(value)
                         .then(() => getAllCategories().then(setCategories))
                         .then(() => setOpen(false))
-                        .catch(console.error);
+                        .catch(console.error)
+                        .finally(() => setLoading(false));
         };
 	return (
 		<>
@@ -58,7 +66,7 @@ export default function Page(): React.JSX.Element {
 					<DataTable rowHeight={40} columns={categoriesColumns} rows={categories || []} />
 				</Grid>
 			</Stack>
-			<Dialog open={open} onClose={() => setOpen(false)}>
+                        <Dialog open={open} onClose={() => setOpen(false)}>
 				<DialogTitle>Add New Category</DialogTitle>
 				<DialogContent sx={{ paddingBottom: 0 }}>
 					<form onSubmit={handleSubmit}>
@@ -78,7 +86,8 @@ export default function Page(): React.JSX.Element {
 						</DialogActions>
 					</form>
 				</DialogContent>
-			</Dialog>
-		</>
-	);
+                        </Dialog>
+                        <LoadingScreen open={loading} />
+                </>
+        );
 }

--- a/src/components/auth/auth-guard.tsx
+++ b/src/components/auth/auth-guard.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
 import Alert from '@mui/material/Alert';
+import LoadingScreen from '@/components/core/loading-screen';
 
 import { paths } from '@/paths';
 import { logger } from '@/lib/default-logger';
@@ -43,8 +44,8 @@ export function AuthGuard({ children }: AuthGuardProps): React.JSX.Element | nul
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Expected
   }, [user, error, isLoading]);
 
-  if (isChecking) {
-    return null;
+  if (isChecking || isLoading) {
+    return <LoadingScreen open />;
   }
 
   if (error) {

--- a/src/components/auth/guest-guard.tsx
+++ b/src/components/auth/guest-guard.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
 import Alert from '@mui/material/Alert';
+import LoadingScreen from '@/components/core/loading-screen';
 
 import { paths } from '@/paths';
 import { logger } from '@/lib/default-logger';
@@ -43,8 +44,8 @@ export function GuestGuard({ children }: GuestGuardProps): React.JSX.Element | n
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Expected
   }, [user, error, isLoading]);
 
-  if (isChecking) {
-    return null;
+  if (isChecking || isLoading) {
+    return <LoadingScreen open />;
   }
 
   if (error) {

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -21,6 +21,7 @@ import { z as zod } from 'zod';
 import { paths } from '@/paths';
 import { authClient } from '@/lib/auth/client';
 import { useUser } from '@/hooks/use-user';
+import LoadingScreen from '@/components/core/loading-screen';
 
 const schema = zod.object({
   email: zod.string().min(1, { message: 'Email is required' }).email(),
@@ -148,6 +149,7 @@ export function SignInForm(): React.JSX.Element {
           Secret1
         </Typography>
       </Alert>
+      <LoadingScreen open={isPending} />
     </Stack>
   );
 }

--- a/src/components/auth/sign-up-form.tsx
+++ b/src/components/auth/sign-up-form.tsx
@@ -21,6 +21,7 @@ import { z as zod } from 'zod';
 import { paths } from '@/paths';
 import { authClient } from '@/lib/auth/client';
 import { useUser } from '@/hooks/use-user';
+import LoadingScreen from '@/components/core/loading-screen';
 
 const schema = zod.object({
   firstName: zod.string().min(1, { message: 'First name is required' }),
@@ -151,6 +152,7 @@ export function SignUpForm(): React.JSX.Element {
         </Stack>
       </form>
       <Alert color="warning">Created users are not persisted</Alert>
+      <LoadingScreen open={isPending} />
     </Stack>
   );
 }

--- a/src/components/core/loading-screen.tsx
+++ b/src/components/core/loading-screen.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+import Backdrop from "@mui/material/Backdrop";
+import CircularProgress from "@mui/material/CircularProgress";
+
+export interface LoadingScreenProps {
+  open: boolean;
+}
+
+export default function LoadingScreen({ open }: LoadingScreenProps): React.JSX.Element {
+  return (
+    <Backdrop
+      open={open}
+      sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+    >
+      <CircularProgress color="inherit" />
+    </Backdrop>
+  );
+}

--- a/src/features/dashboard/account/balance-summary.tsx
+++ b/src/features/dashboard/account/balance-summary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Box, Button, MenuItem, Select, Typography } from "@mui/material";
+import { Box, Button, MenuItem, Select } from "@mui/material";
 import { Grid } from "@mui/system";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 

--- a/src/features/dashboard/account/transaction-breakdown-modal.tsx
+++ b/src/features/dashboard/account/transaction-breakdown-modal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { Button, Dialog, DialogContent, DialogTitle, IconButton, Typography } from "@mui/material";
+import { XIcon } from "@phosphor-icons/react/dist/ssr";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 
 import { TransactionDTO } from "@/types/user";
@@ -52,9 +53,9 @@ const TransactionBreakdownModal: React.FC<Props> = ({ open, onClose, user, month
 		<Dialog open={open} onClose={onClose} fullWidth maxWidth="lg">
 			<DialogTitle>
 				Transactions with {user}
-				<IconButton onClick={onClose} sx={{ float: "right" }}>
-					<Close />
-				</IconButton>
+                                <IconButton onClick={onClose} sx={{ float: "right" }}>
+                                        <XIcon />
+                                </IconButton>
 			</DialogTitle>
 			<DialogContent>
 				<Typography variant="body2" sx={{ mb: 2 }}>

--- a/src/features/dashboard/layout/mobile-nav.tsx
+++ b/src/features/dashboard/layout/mobile-nav.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import RouterLink from 'next/link';
 import { usePathname } from 'next/navigation';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import Stack from '@mui/material/Stack';

--- a/src/features/dashboard/layout/user-popover.tsx
+++ b/src/features/dashboard/layout/user-popover.tsx
@@ -70,7 +70,7 @@ export function UserPopover({ anchorEl, onClose, open }: UserPopoverProps): Reac
           </ListItemIcon>
           Settings
         </MenuItem>
-        <MenuItem component={RouterLink} href={paths.dashboard.account} onClick={onClose}>
+        <MenuItem component={RouterLink} href={paths.dashboard.shareCalculator} onClick={onClose}>
           <ListItemIcon>
             <UserIcon fontSize="var(--icon-fontSize-md)" />
           </ListItemIcon>

--- a/src/lib/api/transactions.ts
+++ b/src/lib/api/transactions.ts
@@ -1,19 +1,23 @@
 import { OverviewResponse, transactions } from "@/types/nav";
-import { SettleUpRequest, TransactionDTO } from "@/types/user";
-
-import { BalanceSummaryDTO, TransactionRequestDTO, TransactionResponseDTO } from "../types/transaction";
+import {
+  BalanceSummaryDTO,
+  SettleUpRequest,
+  TransactionDTO,
+  TransactionRequestDTO,
+  TransactionResponseDTO,
+} from "@/types/user";
 import axiosInstance from "./axios";
 
 export interface TransactionPayload {
-	startDate: string;
-	endDate: string;
-	category: string;
+        startDate: string;
+        endDate: string;
+        category?: string;
 }
 export const getTransactionForGivenRange = async ({
-	startDate,
-	endDate,
-	category = "no-cat-filter",
-}): Promise<OverviewResponse> => {
+        startDate,
+        endDate,
+        category = "no-cat-filter",
+}: TransactionPayload): Promise<OverviewResponse> => {
 	const response = await axiosInstance.get("api/expenses/getExpenses/" + startDate + "/" + endDate + "/" + category);
 	return response.data;
 };

--- a/src/types/nav.d.ts
+++ b/src/types/nav.d.ts
@@ -46,11 +46,6 @@ export interface DashboardAnalyticsResponse {
 	monthlySummary: MonthlySummaryItem[];
 }
 
-export interface Summary {
-	income: number;
-	expense: number;
-	remaining: number;
-}
 
 export interface CategoryBreakdown {
 	[category: string]: number; // e.g., "EMI": 12534.84


### PR DESCRIPTION
## Summary
- add a reusable `LoadingScreen` component
- show loading indicator on sign in/up forms
- show loading overlay during API calls on dashboard pages
- clean up merge conflicts and fix TypeScript issues

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6872e25ba3e0832196deb1cde260c078